### PR TITLE
Feature/ 토큰 재발급 기능 구현

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -56,7 +56,7 @@ export class AuthController {
     }
   };
 
-
+  
   //펫시터 회원가입
   signUpPetsitter = async (req, res, next) => {
     try {
@@ -110,13 +110,42 @@ export class AuthController {
     try {
       const user = req.user;
 
-      await this.authService.signOut({ id: user.id, hashedRefreshToken: 'nodata' });
+      await this.authService.signOut({
+        id: user.id,
+        hashedRefreshToken: 'nodata',
+      });
 
       return res.status(HTTP_STATUS.OK).json({
         status: HTTP_STATUS.OK,
         message: MESSAGES.AUTH.SIGN_OUT.SUCCEED,
-        data: { id: user.id }
-      })
+        data: { id: user.id },
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // 토큰 재발급
+  renewTokens = async (req, res, next) => {
+    try {
+      const user = req.user;
+      const id = user.id;
+      const role = user.role;
+
+      console.log(id, role)
+
+      const { accessToken, refreshToken } =
+        await this.authService.createAccessAndRefreshToken({
+          id,
+          role,
+        });
+
+      return res.status(HTTP_STATUS.OK).json({
+        status: HTTP_STATUS.OK,
+        message: MESSAGES.AUTH.SIGN_IN.TOKEN,
+        accessToken,
+        refreshToken,
+      });
     } catch (error) {
       next(error);
     }

--- a/src/middlewares/require-refresh-token.middleware.js
+++ b/src/middlewares/require-refresh-token.middleware.js
@@ -3,10 +3,12 @@ import { MESSAGES } from '../constants/message.constant.js';
 import jwt from 'jsonwebtoken';
 import { HttpError } from '../errors/http.error.js';
 import { UsersRepository } from '../repositories/users.repository.js';
+import { PetsitterRepository } from '../repositories/petsitters.repository.js';
 import bcrypt from 'bcrypt';
 import { prisma } from '../utils/prisma.utils.js';
 
 const usersRepository = new UsersRepository(prisma);
+const petsittersRepository = new PetsitterRepository(prisma);
 
 export const requireRefreshToken = async (req, res, next) => {
   try {
@@ -38,6 +40,7 @@ export const requireRefreshToken = async (req, res, next) => {
     }
 
     const { id } = payload;
+    const { role } = payload;
 
     const existedRefreshToken = await usersRepository.findOneRefreshTokenId(id);
 
@@ -54,12 +57,16 @@ export const requireRefreshToken = async (req, res, next) => {
       throw new HttpError.Unauthorized(MESSAGES.AUTH.JWT.NO_USER);
     }
 
-    const user = await usersRepository.findOneId(id);
+    const user =
+    role === 'user'
+      ? await usersRepository.findOneId(id)
+      : await petsittersRepository.findPetsitterById({ id });
 
     if (!user) {
       throw new HttpError.Unauthorized(MESSAGES.AUTH.JWT.NO_USER);
     }
-    req.user = user;
+
+    req.user = { ...user, role };
     next();
   } catch (error) {
     next(error);

--- a/src/routers/auth.router.js
+++ b/src/routers/auth.router.js
@@ -40,4 +40,7 @@ authRouter.post(
 // 로그아웃
 authRouter.post('/sign-out', requireRefreshToken, authController.signOut);
 
+// 토큰 재발급
+authRouter.post('/renew-tokens', requireRefreshToken, authController.renewTokens);
+
 export { authRouter };

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -100,8 +100,10 @@ export class AuthService {
     const accessToken = createAccessToken({ id, role });
     const refreshToken = createRefreshToken({ id, role });
 
-    const hashedRefreshToken = bcrypt.hashSync(refreshToken, HASH_SALT_ROUNDS);
-    await this.usersRepository.refreshTokenUpdate({ id, hashedRefreshToken });
+    if( role === 'user') {
+      const hashedRefreshToken = bcrypt.hashSync(refreshToken, HASH_SALT_ROUNDS);
+      await this.usersRepository.refreshTokenUpdate({ id, hashedRefreshToken });
+    }
 
     return { accessToken, refreshToken };
   };


### PR DESCRIPTION
#4 

## 토큰 재발급 API **(🔐 RefreshToken 인증 필요)**

#### AccessToken 만료 시 RefreshToken을 활용해 재발급합니다.

- [x]  **요청 정보**
    - **RefreshToken**(JWT)을 **Request Header의 Authorization** 값(**`req.headers.authorization`**)으로 전달 받습니다.
    - 사용자 정보는 인증 Middleware(`req.user`)를 통해서 전달 받습니다.
- [x]  **비즈니스 로직(데이터 처리)**
    - **AccessToken(Payload**에 `사용자 ID`를 포함하고, **유효기한**이 `1시간`)을 생성합니다.
    - **RefreshToken** (**Payload**: **사용자 ID** 포함, **유효기한**: **`7일`**)을 생성합니다.
    - DB에 저장 된 **RefreshToken을 갱신**합니다.
- [x]  **반환 정보**
    - **AccessToken, RefreshToken**을 반환합니다.
